### PR TITLE
Fix footer translation keys

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -11,18 +11,18 @@ const Footer: React.FC = () => {
       <div className="container mx-auto flex flex-col items-center justify-between gap-4 py-10 md:h-24 md:flex-row md:py-0">
         <div className="flex flex-col items-center gap-4 px-8 md:flex-row md:gap-2 md:px-0">
           <p className="text-center text-sm leading-loose text-muted-foreground md:text-left">
-            © {currentYear} Tools4Anything. {t('all_rights_reserved')}
+            {t('footer.rights', { year: currentYear })}
           </p>
         </div>
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           <Link to="/about" className="hover:text-primary hover:underline">
-            {t('about_us')}
+            {t('footer.links.about')}
           </Link>
           <Link to="/contact" className="hover:text-primary hover:underline">
-            {t('contact')}
+            {t('footer.links.contact')}
           </Link>
           <Link to="/privacy-policy" className="hover:text-primary hover:underline">
-            {t('privacy_policy')}
+            {t('footer.links.privacy')}
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use existing footer translation keys

## Testing
- `npm run test:run` *(fails: Router inside Router errors)*

------
https://chatgpt.com/codex/tasks/task_e_68581442d4c08323974ea1c2d56e6df7