### PR TITLE
Fix audio splitter toast

### DIFF
--- a/src/pages/tools/AudioSplitter.tsx
+++ b/src/pages/tools/AudioSplitter.tsx
@@ -52,8 +52,10 @@ const AudioSplitter = () => {
     if (currentTime > 0 && currentTime < duration) {
       setSplitPoints(prev => [...prev, currentTime].sort((a, b) => a - b));
       toast({
-        title: "t("audio_splitter_page.toasts.add_point")",
-        description: t("audio_splitter_page.toasts.point_added", { time: formatTime(currentTime) })
+        title: t("audio_splitter_page.toasts.add_point"),
+        description: t("audio_splitter_page.toasts.point_added", {
+          time: formatTime(currentTime),
+        }),
       });
     }
   };


### PR DESCRIPTION
## Summary
- fix the toast string in AudioSplitter

## Testing
- `npm test` *(fails: 6 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6858696d99188323992e0b2d7cff1d98