### PR TITLE
Add missing i18n strings and fix references

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -737,6 +737,7 @@
     "converting": "Converting...",
     "converted_title": "Converted File",
     "converted_desc": "Download the converted file",
+    "download_button": "Download Converted File",
     "formats_title": "Supported Formats",
     "placeholder": "Converted file will appear here",
     "toasts": {
@@ -801,6 +802,7 @@
     "merging": "Merging...",
     "merged_title": "Merged File",
     "merged_desc": "Download the merged file",
+    "download_button": "Download Merged File",
     "instructions_title": "Usage Instructions",
     "instructions": [
       "1. Upload files",
@@ -852,8 +854,12 @@
       "success_desc": "File split into {{count}} parts",
       "split_error": "Error splitting file",
       "downloaded": "Part {{index}} saved",
-      "all_downloaded": "All parts saved"
-    }
+      "all_downloaded": "All parts saved",
+      "add_point": "Added split point",
+      "processing_desc": "Splitting audio, please wait"
+    },
+    "play": "Play",
+    "pause": "Pause"
   },
   "footer": {
     "categories": "Categories",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -737,6 +737,7 @@
     "converting": "ממיר...",
     "converted_title": "קובץ מומר",
     "converted_desc": "הורד את הקובץ המומר",
+    "download_button": "הורד את הקובץ שהומר",
     "formats_title": "פורמטים נתמכים",
     "placeholder": "הקובץ המומר יופיע כאן",
     "toasts": {
@@ -801,6 +802,7 @@
     "merging": "מאחד...",
     "merged_title": "קובץ מאוחד",
     "merged_desc": "הורד את הקובץ המאוחד",
+    "download_button": "הורד קובץ מאוחד",
     "instructions_title": "הוראות שימוש",
     "instructions": [
       "1. העלה קבצים",
@@ -852,8 +854,12 @@
       "success_desc": "הקובץ חולק ל-{{count}} חלקים",
       "split_error": "שגיאה בחיתוך הקובץ",
       "downloaded": "חלק {{index}} נשמר",
-      "all_downloaded": "כל החלקים נשמרו"
-    }
+      "all_downloaded": "כל החלקים נשמרו",
+      "add_point": "נקודת חיתוך נוספה",
+      "processing_desc": "מפצל את הקובץ, אנא המתן"
+    },
+    "play": "נגן",
+    "pause": "הפסק"
   },
   "footer": {
     "categories": "קטגוריות",

--- a/src/pages/tools/JWTDecoder.tsx
+++ b/src/pages/tools/JWTDecoder.tsx
@@ -70,7 +70,7 @@ const JWTDecoder = () => {
       if (decodedPayload.admin === true || decodedPayload.role === 'admin') {
         logError(
           ERROR_CODES.SECURITY_VIOLATION,
-          t('jwt_decoder_page.admin_warning'),
+          t('jwt_decoder_page.toasts.admin_warning'),
           'warning'
         );
       }

--- a/src/pages/tools/NameGenerator.tsx
+++ b/src/pages/tools/NameGenerator.tsx
@@ -89,7 +89,7 @@ const NameGenerator = () => {
           subtitle={t('name_generator_page.subtitle')}
           icon={<User className="h-16 w-16 text-indigo-600" />}
           backPath="/categories/generators"
-          backLabel={t('common.back.category')}
+          backLabel={t('common.back_category')}
         />
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- add missing translation keys for audio converter, merger and splitter
- update NameGenerator and JWTDecoder to use correct keys

## Testing
- `npm test` *(fails: You cannot render a <Router> inside another <Router>)*

------
https://chatgpt.com/codex/tasks/task_e_68586d68d3188323844e38608c8f3438