### PR TITLE
Add translations for Currency Converter

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -861,6 +861,20 @@
     "play": "Play",
     "pause": "Pause"
   },
+  "currency_converter_page": {
+    "back": "Back to Finance Tools",
+    "title": "Currency Converter",
+    "subtitle": "Convert between currencies with up-to-date exchange rates.",
+    "loading": "Loading currency list...",
+    "amount_label": "Amount",
+    "from_label": "From Currency",
+    "to_label": "To Currency",
+    "equal": "is equal to:",
+    "toasts": {
+      "load_error": "Error loading currencies",
+      "convert_error": "Error converting currency"
+    }
+  },
   "footer": {
     "categories": "Categories",
     "popular": "Popular",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -861,6 +861,20 @@
     "play": "נגן",
     "pause": "הפסק"
   },
+  "currency_converter_page": {
+    "back": "חזרה לכלי פיננסים",
+    "title": "ממיר מטבעות",
+    "subtitle": "המר בין מטבעות שונים עם שערי חליפין עדכניים.",
+    "loading": "טוען רשימת מטבעות...",
+    "amount_label": "סכום",
+    "from_label": "ממטבע",
+    "to_label": "למטבע",
+    "equal": "שווה ל:",
+    "toasts": {
+      "load_error": "שגיאה בטעינת המטבעות",
+      "convert_error": "שגיאה בהמרת המטבע"
+    }
+  },
   "footer": {
     "categories": "קטגוריות",
     "popular": "פופולריים",

--- a/src/pages/tools/CurrencyConverter.tsx
+++ b/src/pages/tools/CurrencyConverter.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Loader2, ArrowLeft, ArrowRightLeft } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
 const API_BASE_URL = 'https://api.frankfurter.app';
@@ -25,6 +26,7 @@ const CurrencyConverter = () => {
 
     const { toast } = useToast();
     const navigate = useNavigate();
+    const { t } = useTranslation();
 
     useEffect(() => {
         const fetchCurrencies = async () => {
@@ -33,7 +35,7 @@ const CurrencyConverter = () => {
                 const data: Currencies = await response.json();
                 setCurrencies(data);
             } catch (error) {
-                toast({ title: "שגיאה בטעינת המטבעות", variant: "destructive" });
+                toast({ title: t('currency_converter_page.toasts.load_error'), variant: 'destructive' });
             } finally {
                 setIsCurrenciesLoading(false);
             }
@@ -57,7 +59,7 @@ const CurrencyConverter = () => {
             const data = await response.json();
             setConvertedAmount(data.rates[toCurrency]);
         } catch (error) {
-            toast({ title: "שגיאה בהמרת המטבע", variant: "destructive" });
+            toast({ title: t('currency_converter_page.toasts.convert_error'), variant: 'destructive' });
         } finally {
             setIsLoading(false);
         }
@@ -82,28 +84,28 @@ const CurrencyConverter = () => {
         <div className="container mx-auto max-w-2xl p-4">
              <Button onClick={() => navigate("/categories/finance-tools")} variant="outline" className="mb-4">
                 <ArrowLeft className="h-4 w-4 mr-2" />
-                חזרה לכלי פיננסים
+                {t('currency_converter_page.back')}
             </Button>
             <Card>
                 <CardHeader>
-                    <CardTitle>ממיר מטבעות</CardTitle>
-                    <CardDescription>המר בין מטבעות שונים עם שערי חליפין עדכניים.</CardDescription>
+                    <CardTitle>{t('currency_converter_page.title')}</CardTitle>
+                    <CardDescription>{t('currency_converter_page.subtitle')}</CardDescription>
                 </CardHeader>
                 <CardContent>
                     {isCurrenciesLoading ? (
                         <div className="flex items-center justify-center p-8">
                             <Loader2 className="h-8 w-8 animate-spin" />
-                            <p className="ml-4">טוען רשימת מטבעות...</p>
+                            <p className="ml-4">{t('currency_converter_page.loading')}</p>
                         </div>
                     ) : (
                         <div className="space-y-4">
                             <div className="space-y-2">
-                                <Label htmlFor="amount">סכום</Label>
+                                <Label htmlFor="amount">{t('currency_converter_page.amount_label')}</Label>
                                 <Input id="amount" type="number" value={amount} onChange={handleAmountChange} />
                             </div>
                             <div className="flex items-center justify-between gap-2">
                                 <div className="flex-1 space-y-2">
-                                    <Label>ממטבע</Label>
+                                    <Label>{t('currency_converter_page.from_label')}</Label>
                                     <Select value={fromCurrency} onValueChange={setFromCurrency}>
                                         <SelectTrigger><SelectValue/></SelectTrigger>
                                         <SelectContent>
@@ -117,7 +119,7 @@ const CurrencyConverter = () => {
                                     <ArrowRightLeft className="h-5 w-5"/>
                                 </Button>
                                 <div className="flex-1 space-y-2">
-                                    <Label>למטבע</Label>
+                                    <Label>{t('currency_converter_page.to_label')}</Label>
                                     <Select value={toCurrency} onValueChange={setToCurrency}>
                                         <SelectTrigger><SelectValue/></SelectTrigger>
                                         <SelectContent>
@@ -133,7 +135,7 @@ const CurrencyConverter = () => {
                                     <Loader2 className="h-8 w-8 animate-spin mx-auto"/>
                                 ) : (
                                     <>
-                                        <p className="text-lg font-semibold">{amount} {currencies[fromCurrency]} שווה ל:</p>
+                                        <p className="text-lg font-semibold">{amount} {currencies[fromCurrency]} {t('currency_converter_page.equal')}</p>
                                         <p className="text-4xl font-bold text-green-600">{convertedAmount?.toFixed(2) ?? '0.00'} {currencies[toCurrency]}</p>
                                     </>
                                 )}


### PR DESCRIPTION
## Summary
- localize Currency Converter page
- insert `currency_converter_page` object in both translation files

## Testing
- `npm run validate` *(fails: unexpected lint errors)*
- `npm test` *(fails: many test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6858743fcfec83238510d59c392e4659