### PR TITLE
Localize LineSorter page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -875,6 +875,25 @@
       "convert_error": "Error converting currency"
     }
   },
+  "line_sorter_page": {
+    "back": "Back to Text Tools",
+    "title": "Line Sorter",
+    "subtitle": "Sort lines of text alphabetically",
+    "input_title": "Input Text",
+    "input_desc": "Enter lines of text to sort",
+    "placeholder": "Enter lines of text here...",
+    "az_button": "A-Z",
+    "za_button": "Z-A",
+    "sort_button": "Sort Lines",
+    "sorted_title": "Sorted Lines",
+    "sorted_desc": "Your lines sorted alphabetically",
+    "sorted_placeholder": "Sorted lines will appear here...",
+    "copy_button": "Copy Result",
+    "toasts": {
+      "copied_title": "Copied!",
+      "copied_desc": "Sorted lines copied to clipboard"
+    }
+  },
   "footer": {
     "categories": "Categories",
     "popular": "Popular",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -875,6 +875,25 @@
       "convert_error": "שגיאה בהמרת המטבע"
     }
   },
+  "line_sorter_page": {
+    "back": "חזרה לכלי טקסט",
+    "title": "ממיין שורות",
+    "subtitle": "מיין שורות טקסט בסדר אלפביתי",
+    "input_title": "טקסט קלט",
+    "input_desc": "הזן שורות טקסט למיון",
+    "placeholder": "הכנס כאן שורות טקסט...",
+    "az_button": "א-ת",
+    "za_button": "ת-א",
+    "sort_button": "מיין שורות",
+    "sorted_title": "שורות ממויינות",
+    "sorted_desc": "השורות שלך ממויינות בסדר אלפביתי",
+    "sorted_placeholder": "השורות הממויינות יופיעו כאן...",
+    "copy_button": "העתק תוצאה",
+    "toasts": {
+      "copied_title": "הועתק!",
+      "copied_desc": "השורות הממויינות הועתקו ללוח"
+    }
+  },
   "footer": {
     "categories": "קטגוריות",
     "popular": "פופולריים",

--- a/src/pages/tools/LineSorter.tsx
+++ b/src/pages/tools/LineSorter.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { ArrowUpDown, Copy, ArrowLeft } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 const LineSorter = () => {
   const [input, setInput] = useState("");
@@ -13,6 +14,7 @@ const LineSorter = () => {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
   const { toast } = useToast();
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const sortLines = () => {
     const lines = input.split('\n').filter(line => line.trim() !== '');
@@ -24,7 +26,10 @@ const LineSorter = () => {
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(output);
-    toast({ title: "Copied!", description: "Sorted lines copied to clipboard" });
+    toast({
+      title: t('line_sorter_page.toasts.copied_title'),
+      description: t('line_sorter_page.toasts.copied_desc')
+    });
   };
 
   return (
@@ -36,26 +41,26 @@ const LineSorter = () => {
           className="mb-4"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Text Tools
+          {t('line_sorter_page.back')}
         </Button>
 
         <div className="mb-8 text-center">
           <ArrowUpDown className="h-12 w-12 mx-auto mb-4 text-blue-600" />
-          <h1 className="text-4xl font-bold mb-2">Line Sorter</h1>
-          <p className="text-gray-600">Sort lines of text alphabetically</p>
+          <h1 className="text-4xl font-bold mb-2">{t('line_sorter_page.title')}</h1>
+          <p className="text-gray-600">{t('line_sorter_page.subtitle')}</p>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <Card>
             <CardHeader>
-              <CardTitle>Input Text</CardTitle>
+              <CardTitle>{t('line_sorter_page.input_title')}</CardTitle>
               <CardDescription>
-                Enter lines of text to sort
+                {t('line_sorter_page.input_desc')}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <Textarea
-                placeholder="Enter lines of text here..."
+                placeholder={t('line_sorter_page.placeholder')}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 className="min-h-48"
@@ -66,27 +71,27 @@ const LineSorter = () => {
                   variant={sortOrder === "asc" ? "default" : "outline"}
                   className="flex-1"
                 >
-                  A-Z
+                  {t('line_sorter_page.az_button')}
                 </Button>
                 <Button 
                   onClick={() => setSortOrder("desc")} 
                   variant={sortOrder === "desc" ? "default" : "outline"}
                   className="flex-1"
                 >
-                  Z-A
+                  {t('line_sorter_page.za_button')}
                 </Button>
               </div>
               <Button onClick={sortLines} className="w-full">
-                Sort Lines
+                {t('line_sorter_page.sort_button')}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>Sorted Lines</CardTitle>
+              <CardTitle>{t('line_sorter_page.sorted_title')}</CardTitle>
               <CardDescription>
-                Your lines sorted alphabetically
+                {t('line_sorter_page.sorted_desc')}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -94,12 +99,12 @@ const LineSorter = () => {
                 value={output}
                 readOnly
                 className="min-h-48 bg-gray-50"
-                placeholder="Sorted lines will appear here..."
+                placeholder={t('line_sorter_page.sorted_placeholder')}
               />
               {output && (
                 <Button onClick={copyToClipboard} variant="outline" className="w-full">
                   <Copy className="h-4 w-4 mr-2" />
-                  Copy Result
+                  {t('line_sorter_page.copy_button')}
                 </Button>
               )}
             </CardContent>


### PR DESCRIPTION
## Summary
- add `line_sorter_page` entries in English and Hebrew translations
- translate LineSorter page strings via `t('line_sorter_page.*')`

## Testing
- `npm run lint` *(fails: 79 problems)*
- `npm run test:run` *(fails due to Router errors)*

------
https://chatgpt.com/codex/tasks/task_e_685876a3a1b48323a1f48ab4e11c7919