### PR TITLE
Add i18n for LoanCalculator page

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -520,6 +520,29 @@
       "obese": "Obese"
     }
   },
+  "loan_calculator_page": {
+    "back": "Back to Calculators",
+    "title": "Loan Calculator",
+    "subtitle": "Calculate monthly loan payments and total costs",
+    "details_title": "Loan Details",
+    "details_desc": "Enter your loan information",
+    "amount_label": "Loan Amount ($)",
+    "interest_label": "Annual Interest Rate (%)",
+    "term_label": "Loan Term (Years)",
+    "button": "Calculate Payment",
+    "summary_title": "Payment Summary",
+    "summary_desc": "Your loan payment breakdown",
+    "monthly_label": "Monthly Payment",
+    "total_payment_label": "Total Payment",
+    "total_interest_label": "Total Interest",
+    "breakdown_title": "Payment Breakdown",
+    "principal_label": "Principal",
+    "interest_rate_label": "Interest Rate",
+    "loan_term_label": "Loan Term",
+    "annually_suffix": "annually",
+    "years_unit": "years",
+    "payments_unit": "payments"
+  },
   "barcode_generator_page": {
     "back": "Back to Image Tools",
     "title": "Barcode Generator",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -520,6 +520,29 @@
       "obese": "השמנת יתר" 
     } 
   },
+  "loan_calculator_page": {
+    "back": "חזרה למחשבונים",
+    "title": "מחשבון הלוואות",
+    "subtitle": "חשב תשלומים חודשיים וסך עלות ההלוואה",
+    "details_title": "פרטי הלוואה",
+    "details_desc": "הזן את פרטי ההלוואה שלך",
+    "amount_label": "סכום הלוואה ($)",
+    "interest_label": "ריבית שנתית (%)",
+    "term_label": "משך ההלוואה (שנים)",
+    "button": "חשב תשלום",
+    "summary_title": "סיכום תשלומים",
+    "summary_desc": "פירוט תשלומי ההלוואה",
+    "monthly_label": "תשלום חודשי",
+    "total_payment_label": "סך הכל לתשלום",
+    "total_interest_label": "סה\"כ ריבית",
+    "breakdown_title": "פירוט תשלום",
+    "principal_label": "קרן",
+    "interest_rate_label": "ריבית",
+    "loan_term_label": "משך ההלוואה",
+    "annually_suffix": "בשנה",
+    "years_unit": "שנים",
+    "payments_unit": "תשלומים"
+  },
   "barcode_generator_page": {
     "back": "חזרה לכלי תמונות",
     "title": "מחולל ברקוד",

--- a/src/pages/tools/LoanCalculator.tsx
+++ b/src/pages/tools/LoanCalculator.tsx
@@ -5,8 +5,10 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Calculator, ArrowLeft, TrendingUp } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 
 const LoanCalculator = () => {
+  const { t } = useTranslation();
   const [principal, setPrincipal] = useState("");
   const [interestRate, setInterestRate] = useState("");
   const [loanTerm, setLoanTerm] = useState("");
@@ -52,26 +54,26 @@ const LoanCalculator = () => {
           className="mb-4"
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Back to Calculators
+          {t('loan_calculator_page.back')}
         </Button>
 
         <div className="mb-8 text-center">
           <TrendingUp className="h-12 w-12 mx-auto mb-4 text-blue-600" />
-          <h1 className="text-4xl font-bold mb-2">Loan Calculator</h1>
-          <p className="text-gray-600">Calculate monthly loan payments and total costs</p>
+          <h1 className="text-4xl font-bold mb-2">{t('loan_calculator_page.title')}</h1>
+          <p className="text-gray-600">{t('loan_calculator_page.subtitle')}</p>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
           <Card>
             <CardHeader>
-              <CardTitle>Loan Details</CardTitle>
+              <CardTitle>{t('loan_calculator_page.details_title')}</CardTitle>
               <CardDescription>
-                Enter your loan information
+                {t('loan_calculator_page.details_desc')}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div>
-                <label className="block text-sm font-medium mb-2">Loan Amount ($)</label>
+                <label className="block text-sm font-medium mb-2">{t('loan_calculator_page.amount_label')}</label>
                 <Input
                   type="number"
                   placeholder="100000"
@@ -82,7 +84,7 @@ const LoanCalculator = () => {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Annual Interest Rate (%)</label>
+                <label className="block text-sm font-medium mb-2">{t('loan_calculator_page.interest_label')}</label>
                 <Input
                   type="number"
                   placeholder="5.5"
@@ -93,7 +95,7 @@ const LoanCalculator = () => {
               </div>
 
               <div>
-                <label className="block text-sm font-medium mb-2">Loan Term (Years)</label>
+                <label className="block text-sm font-medium mb-2">{t('loan_calculator_page.term_label')}</label>
                 <Input
                   type="number"
                   placeholder="30"
@@ -104,21 +106,21 @@ const LoanCalculator = () => {
 
               <Button onClick={calculateLoan} className="w-full">
                 <Calculator className="h-4 w-4 mr-2" />
-                Calculate Payment
+                {t('loan_calculator_page.button')}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>Payment Summary</CardTitle>
+              <CardTitle>{t('loan_calculator_page.summary_title')}</CardTitle>
               <CardDescription>
-                Your loan payment breakdown
+                {t('loan_calculator_page.summary_desc')}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="bg-blue-50 p-4 rounded-lg">
-                <div className="text-sm text-blue-600 font-medium">Monthly Payment</div>
+                <div className="text-sm text-blue-600 font-medium">{t('loan_calculator_page.monthly_label')}</div>
                 <div className="text-3xl font-bold text-blue-700">
                   ${results.monthlyPayment.toFixed(2)}
                 </div>
@@ -126,13 +128,13 @@ const LoanCalculator = () => {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="bg-green-50 p-4 rounded-lg">
-                  <div className="text-sm text-green-600 font-medium">Total Payment</div>
+                  <div className="text-sm text-green-600 font-medium">{t('loan_calculator_page.total_payment_label')}</div>
                   <div className="text-xl font-bold text-green-700">
                     ${results.totalPayment.toFixed(2)}
                   </div>
                 </div>
                 <div className="bg-orange-50 p-4 rounded-lg">
-                  <div className="text-sm text-orange-600 font-medium">Total Interest</div>
+                  <div className="text-sm text-orange-600 font-medium">{t('loan_calculator_page.total_interest_label')}</div>
                   <div className="text-xl font-bold text-orange-700">
                     ${results.totalInterest.toFixed(2)}
                   </div>
@@ -141,19 +143,19 @@ const LoanCalculator = () => {
 
               {results.monthlyPayment > 0 && (
                 <div className="mt-6 p-4 bg-gray-50 rounded-lg">
-                  <h4 className="font-semibold mb-2">Payment Breakdown</h4>
+                  <h4 className="font-semibold mb-2">{t('loan_calculator_page.breakdown_title')}</h4>
                   <div className="space-y-2 text-sm">
                     <div className="flex justify-between">
-                      <span>Principal:</span>
+                      <span>{t('loan_calculator_page.principal_label')}:</span>
                       <span>${parseFloat(principal || "0").toLocaleString()}</span>
                     </div>
                     <div className="flex justify-between">
-                      <span>Interest Rate:</span>
-                      <span>{interestRate}% annually</span>
+                      <span>{t('loan_calculator_page.interest_rate_label')}:</span>
+                      <span>{interestRate}% {t('loan_calculator_page.annually_suffix')}</span>
                     </div>
                     <div className="flex justify-between">
-                      <span>Loan Term:</span>
-                      <span>{loanTerm} years ({(parseFloat(loanTerm) || 0) * 12} payments)</span>
+                      <span>{t('loan_calculator_page.loan_term_label')}:</span>
+                      <span>{loanTerm} {t('loan_calculator_page.years_unit')} ({(parseFloat(loanTerm) || 0) * 12} {t('loan_calculator_page.payments_unit')})</span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- add `loan_calculator_page` object to English and Hebrew translations
- localize LoanCalculator page using `t()` calls

## Testing
- `npm run validate` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685876492c6883239cbfb561f2887f0d