### PR TITLE
Fix translation duplicates

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -421,66 +421,6 @@
       "expired": "Token expired at {{date}}"
     }
   },
-  "regex_tester_page": {
-    "back": "Back to Developer Tools",
-    "title": "Regex Tester",
-    "subtitle": "Test and debug regular expressions easily",
-    "pattern_title": "Regex Pattern",
-    "pattern_desc": "Enter your regex pattern",
-    "test_label": "Test Text",
-    "regex_placeholder": "Enter regex pattern here...",
-    "text_placeholder": "Enter text to test...",
-    "test_button": "Test Regex",
-    "matches_title": "Matches Found: {{count}}",
-    "position": "Position: {{start}}-{{end}}",
-    "samples_title": "Common Patterns",
-    "samples_desc": "Click to copy",
-    "samples": {
-      "email": "Email",
-      "phone": "Phone",
-      "url": "URL",
-      "number": "Number",
-      "word": "Word",
-      "date": "Date"
-    },
-    "toasts": {
-      "error_title": "Error",
-      "no_pattern": "Please enter a regex pattern",
-      "success_title": "Done!",
-      "found": "{{count}} matches found",
-      "invalid": "Invalid regular expression"
-    }
-  },
-  "jwt_decoder_page": {
-    "back": "Back to Developer Tools",
-    "title": "JWT Decoder",
-    "subtitle": "Decode JWT tokens and view their contents",
-    "security_warning_title": "Security Warning",
-    "security_warning_desc": "Do not share real JWT tokens containing sensitive data. Use sample tokens only on public sites.",
-    "token_title": "JWT Token",
-    "token_desc": "Paste the token you want to decode",
-    "decode_button": "Decode JWT",
-    "header_title": "Header",
-    "header_desc": "Information about the algorithm and token type",
-    "payload_title": "Payload",
-    "payload_desc": "Data encoded in the token",
-    "signature_title": "Signature",
-    "signature_desc": "Digital signature (cannot be verified without the secret key)",
-    "copy_button": "Copy",
-    "toasts": {
-      "success_title": "Success!",
-      "success_desc": "JWT decoded successfully",
-      "copied_title": "Copied!",
-      "copied_desc": "{{type}} copied to clipboard",
-      "error": "Error decoding JWT - ensure the token is valid",
-      "invalid": "Invalid JWT token",
-      "no_token": "Please enter a JWT token",
-      "invalid_header": "Invalid JWT header",
-      "invalid_payload": "Invalid JWT payload",
-      "admin_warning": "Admin privileges token detected - verify the source",
-      "expired": "Token expired at {{date}}"
-    }
-  },
   "video_trimmer_page": {
     "back": "Back to Video Tools",
     "title": "Video Trimmer",
@@ -737,6 +677,7 @@
     "converting": "Converting...",
     "converted_title": "Converted File",
     "converted_desc": "Download the converted file",
+    "download_button": "Download Converted File",
     "formats_title": "Supported Formats",
     "placeholder": "Converted file will appear here",
     "toasts": {
@@ -801,6 +742,7 @@
     "merging": "Merging...",
     "merged_title": "Merged File",
     "merged_desc": "Download the merged file",
+    "download_button": "Download Merged File",
     "instructions_title": "Usage Instructions",
     "instructions": [
       "1. Upload files",
@@ -852,8 +794,12 @@
       "success_desc": "File split into {{count}} parts",
       "split_error": "Error splitting file",
       "downloaded": "Part {{index}} saved",
-      "all_downloaded": "All parts saved"
-    }
+      "all_downloaded": "All parts saved",
+      "add_point": "Added split point",
+      "processing_desc": "Splitting audio, please wait"
+    },
+    "play": "Play",
+    "pause": "Pause"
   },
   "footer": {
     "categories": "Categories",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -421,66 +421,6 @@
       "expired": "הטוקן פג תוקף ב-{{date}}"
     }
   },
-  "regex_tester_page": {
-    "back": "חזרה לכלי מפתחים",
-    "title": "בודק ביטויים רגולריים",
-    "subtitle": "בדוק ופתח ביטויים רגולריים בקלות",
-    "pattern_title": "ביטוי רגולרי",
-    "pattern_desc": "הכנס את הביטוי הרגולרי שלך",
-    "test_label": "טקסט לבדיקה",
-    "regex_placeholder": "הכנס ביטוי רגולרי כאן...",
-    "text_placeholder": "הכנס טקסט לבדיקה...",
-    "test_button": "בדוק ביטוי רגולרי",
-    "matches_title": "התאמות שנמצאו: {{count}}",
-    "position": "מיקום: {{start}}-{{end}}",
-    "samples_title": "דוגמאות נפוצות",
-    "samples_desc": "לחץ להעתקה",
-    "samples": {
-      "email": "אימייל",
-      "phone": "טלפון",
-      "url": "URL",
-      "number": "מספר",
-      "word": "מילה",
-      "date": "תאריך"
-    },
-    "toasts": {
-      "error_title": "שגיאה",
-      "no_pattern": "אנא הכנס ביטוי רגולרי",
-      "success_title": "הושלם!",
-      "found": "נמצאו {{count}} התאמות",
-      "invalid": "ביטוי רגולרי לא תקין"
-    }
-  },
-  "jwt_decoder_page": {
-    "back": "חזרה לכלי מפתחים",
-    "title": "מפענח JWT",
-    "subtitle": "פענח טוקני JWT וצפה בתוכן שלהם",
-    "security_warning_title": "אזהרת אבטחה",
-    "security_warning_desc": "אל תשתף טוקני JWT אמיתיים המכילים מידע רגיש. השתמש בטוקנים לדוגמה בלבד באתרים ציבוריים.",
-    "token_title": "טוקן JWT",
-    "token_desc": "הדבק כאן את הטוקן שברצונך לפענח",
-    "decode_button": "פענח JWT",
-    "header_title": "Header",
-    "header_desc": "מידע על האלגוריתם וסוג הטוקן",
-    "payload_title": "Payload",
-    "payload_desc": "הנתונים המקודדים בטוקן",
-    "signature_title": "Signature",
-    "signature_desc": "החתימה הדיגיטלית (לא ניתן לאמת ללא המפתח הסודי)",
-    "copy_button": "העתק",
-    "toasts": {
-      "success_title": "הצלחה!",
-      "success_desc": "טוקן JWT פוענח בהצלחה",
-      "copied_title": "הועתק!",
-      "copied_desc": "{{type}} הועתק ללוח",
-      "error": "שגיאה בפענוח JWT - ודא שהטוקן תקין",
-      "invalid": "JWT לא תקין",
-      "no_token": "אנא הכנס טוקן JWT",
-      "invalid_header": "כותרת JWT לא תקינה - לא ניתן לפענח",
-      "invalid_payload": "תוכן JWT לא תקין - לא ניתן לפענח",
-      "admin_warning": "זוהה טוקן עם הרשאות מנהל - יש לבדוק את מקור הטוקן",
-      "expired": "הטוקן פג תוקף ב-{{date}}"
-    }
-  },
   "video_trimmer_page": {
     "back": "חזרה לכלי וידאו",
     "title": "חיתוך וידאו",
@@ -737,6 +677,7 @@
     "converting": "ממיר...",
     "converted_title": "קובץ מומר",
     "converted_desc": "הורד את הקובץ המומר",
+    "download_button": "הורד את הקובץ שהומר",
     "formats_title": "פורמטים נתמכים",
     "placeholder": "הקובץ המומר יופיע כאן",
     "toasts": {
@@ -801,6 +742,7 @@
     "merging": "מאחד...",
     "merged_title": "קובץ מאוחד",
     "merged_desc": "הורד את הקובץ המאוחד",
+    "download_button": "הורד קובץ מאוחד",
     "instructions_title": "הוראות שימוש",
     "instructions": [
       "1. העלה קבצים",
@@ -852,8 +794,12 @@
       "success_desc": "הקובץ חולק ל-{{count}} חלקים",
       "split_error": "שגיאה בחיתוך הקובץ",
       "downloaded": "חלק {{index}} נשמר",
-      "all_downloaded": "כל החלקים נשמרו"
-    }
+      "all_downloaded": "כל החלקים נשמרו",
+      "add_point": "נקודת חיתוך נוספה",
+      "processing_desc": "מפצל את הקובץ, אנא המתן"
+    },
+    "play": "נגן",
+    "pause": "הפסק"
   },
   "footer": {
     "categories": "קטגוריות",

--- a/src/pages/tools/JWTDecoder.tsx
+++ b/src/pages/tools/JWTDecoder.tsx
@@ -70,7 +70,7 @@ const JWTDecoder = () => {
       if (decodedPayload.admin === true || decodedPayload.role === 'admin') {
         logError(
           ERROR_CODES.SECURITY_VIOLATION,
-          t('jwt_decoder_page.admin_warning'),
+          t('jwt_decoder_page.toasts.admin_warning'),
           'warning'
         );
       }

--- a/src/pages/tools/NameGenerator.tsx
+++ b/src/pages/tools/NameGenerator.tsx
@@ -89,7 +89,7 @@ const NameGenerator = () => {
           subtitle={t('name_generator_page.subtitle')}
           icon={<User className="h-16 w-16 text-indigo-600" />}
           backPath="/categories/generators"
-          backLabel={t('common.back.category')}
+          backLabel={t('common.back_category')}
         />
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">


### PR DESCRIPTION
## Summary
- remove duplicated blocks in English and Hebrew translations

## Testing
- `npm test` *(fails: You cannot render a <Router> inside another <Router>)*

------
https://chatgpt.com/codex/tasks/task_e_68586d68d3188323844e38608c8f3438