### PR TITLE
Add translations for Base64 and Random Number tools

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -917,6 +917,57 @@
       "copied_desc": "Sorted lines copied to clipboard"
     }
   },
+  "base64_encoder_page": {
+    "title": "Base64 Encoder/Decoder",
+    "subtitle": "Encode and decode Base64 strings",
+    "input_title": "Input",
+    "input_desc_encode": "Enter text to encode",
+    "input_desc_decode": "Enter Base64 to decode",
+    "switch_to_encode": "Switch to Encode",
+    "switch_to_decode": "Switch to Decode",
+    "placeholders": {
+      "encode": "Enter text to encode...",
+      "decode": "Enter Base64 to decode...",
+      "output": "Result will appear here..."
+    },
+    "buttons": {
+      "encode": "Encode",
+      "decode": "Decode",
+      "copy": "Copy Result"
+    },
+    "output_title": "Output",
+    "output_desc_encode": "Encoded result",
+    "output_desc_decode": "Decoded result",
+    "toasts": {
+      "error_title": "Error",
+      "error_desc": "Invalid input for decoding",
+      "copied_title": "Copied!",
+      "copied_desc": "Result copied to clipboard"
+    }
+  },
+  "random_number_generator_page": {
+    "title": "Random Number Generator",
+    "subtitle": "Generate random numbers within a range",
+    "back": "Back to Generators",
+    "settings_title": "Settings",
+    "settings_desc": "Set parameters for generating numbers",
+    "min_label": "Minimum",
+    "max_label": "Maximum",
+    "count_label": "Number of Values",
+    "allow_duplicates": "Allow duplicates",
+    "generate_button": "Generate Numbers",
+    "results_title": "Results",
+    "results_desc": "Generated random numbers",
+    "copy": "Copy",
+    "regenerate": "Generate Again",
+    "empty_prompt": "Click \"Generate Numbers\" to start",
+    "toasts": {
+      "range_error": "Minimum value must be less than maximum",
+      "duplicate_error": "Cannot generate that many unique numbers in the range",
+      "generated": "Random numbers generated successfully!",
+      "copied": "Numbers copied to clipboard!"
+    }
+  },
   "footer": {
     "categories": "Categories",
     "popular": "Popular",

--- a/public/locales/he/translation.json
+++ b/public/locales/he/translation.json
@@ -917,6 +917,57 @@
       "copied_desc": "השורות הממויינות הועתקו ללוח"
     }
   },
+  "base64_encoder_page": {
+    "title": "מקודד/מפענח Base64",
+    "subtitle": "קידוד ופענוח מחרוזות Base64",
+    "input_title": "קלט",
+    "input_desc_encode": "הזן טקסט לקידוד",
+    "input_desc_decode": "הזן Base64 לפענוח",
+    "switch_to_encode": "החלף לקידוד",
+    "switch_to_decode": "החלף לפענוח",
+    "placeholders": {
+      "encode": "הזן טקסט לקידוד...",
+      "decode": "הזן Base64 לפענוח...",
+      "output": "התוצאה תופיע כאן..."
+    },
+    "buttons": {
+      "encode": "קודד",
+      "decode": "פענח",
+      "copy": "העתק תוצאה"
+    },
+    "output_title": "פלט",
+    "output_desc_encode": "תוצאה מקודדת",
+    "output_desc_decode": "תוצאה מפוענחת",
+    "toasts": {
+      "error_title": "שגיאה",
+      "error_desc": "קלט לא תקין לפענוח",
+      "copied_title": "הועתק!",
+      "copied_desc": "התוצאה הועתקה ללוח"
+    }
+  },
+  "random_number_generator_page": {
+    "title": "מחולל מספרים אקראיים",
+    "subtitle": "צור מספרים אקראיים בטווח שתבחר",
+    "back": "חזרה לגנרטורים",
+    "settings_title": "הגדרות",
+    "settings_desc": "קבע את הפרמטרים ליצירת המספרים",
+    "min_label": "מינימום",
+    "max_label": "מקסימום",
+    "count_label": "כמות מספרים",
+    "allow_duplicates": "אפשר כפילויות",
+    "generate_button": "צור מספרים",
+    "results_title": "תוצאות",
+    "results_desc": "המספרים האקראיים שנוצרו",
+    "copy": "העתק",
+    "regenerate": "צור שוב",
+    "empty_prompt": "לחץ על \"צור מספרים\" כדי להתחיל",
+    "toasts": {
+      "range_error": "הערך המינימלי חייב להיות קטן מהמקסימלי",
+      "duplicate_error": "לא ניתן ליצור מספר זה של מספרים ייחודיים בטווח הנתון",
+      "generated": "מספרים אקראיים נוצרו בהצלחה!",
+      "copied": "המספרים הועתקו ללוח!"
+    }
+  },
   "footer": {
     "categories": "קטגוריות",
     "popular": "פופולריים",

--- a/src/pages/tools/Base64Encoder.tsx
+++ b/src/pages/tools/Base64Encoder.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -11,6 +12,7 @@ const Base64Encoder = () => {
   const [output, setOutput] = useState("");
   const [mode, setMode] = useState<"encode" | "decode">("encode");
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   const processText = () => {
     try {
@@ -22,13 +24,19 @@ const Base64Encoder = () => {
         setOutput(decoded);
       }
     } catch (error) {
-      toast({ title: "Error", description: "Invalid input for decoding" });
+      toast({
+        title: t("base64_encoder_page.toasts.error_title"),
+        description: t("base64_encoder_page.toasts.error_desc")
+      });
     }
   };
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(output);
-    toast({ title: "Copied!", description: "Result copied to clipboard" });
+    toast({
+      title: t("base64_encoder_page.toasts.copied_title"),
+      description: t("base64_encoder_page.toasts.copied_desc")
+    });
   };
 
   const switchMode = () => {
@@ -42,8 +50,8 @@ const Base64Encoder = () => {
       <div className="container mx-auto max-w-4xl">
         <div className="mb-8 text-center">
           <Code className="h-12 w-12 mx-auto mb-4 text-blue-600" />
-          <h1 className="text-4xl font-bold mb-2">Base64 Encoder/Decoder</h1>
-          <p className="text-gray-600">Encode and decode Base64 strings</p>
+          <h1 className="text-4xl font-bold mb-2">{t('base64_encoder_page.title')}</h1>
+          <p className="text-gray-600">{t('base64_encoder_page.subtitle')}</p>
         </div>
 
         <div className="grid gap-6 lg:grid-cols-2">
@@ -51,35 +59,47 @@ const Base64Encoder = () => {
             <CardHeader>
               <div className="flex items-center justify-between">
                 <div>
-                  <CardTitle>Input</CardTitle>
+                  <CardTitle>{t('base64_encoder_page.input_title')}</CardTitle>
                   <CardDescription>
-                    Enter text to {mode}
+                    {mode === 'encode'
+                      ? t('base64_encoder_page.input_desc_encode')
+                      : t('base64_encoder_page.input_desc_decode')}
                   </CardDescription>
                 </div>
                 <Button onClick={switchMode} variant="outline" size="sm">
                   <RotateCcw className="h-4 w-4 mr-2" />
-                  Switch to {mode === "encode" ? "Decode" : "Encode"}
+                  {mode === 'encode'
+                    ? t('base64_encoder_page.switch_to_decode')
+                    : t('base64_encoder_page.switch_to_encode')}
                 </Button>
               </div>
             </CardHeader>
             <CardContent className="space-y-4">
               <Textarea
-                placeholder={mode === "encode" ? "Enter text to encode..." : "Enter Base64 to decode..."}
+                placeholder={
+                  mode === 'encode'
+                    ? t('base64_encoder_page.placeholders.encode')
+                    : t('base64_encoder_page.placeholders.decode')
+                }
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 className="min-h-48"
               />
               <Button onClick={processText} className="w-full">
-                {mode === "encode" ? "Encode" : "Decode"}
+                {mode === 'encode'
+                  ? t('base64_encoder_page.buttons.encode')
+                  : t('base64_encoder_page.buttons.decode')}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>Output</CardTitle>
+              <CardTitle>{t('base64_encoder_page.output_title')}</CardTitle>
               <CardDescription>
-                {mode === "encode" ? "Encoded" : "Decoded"} result
+                {mode === 'encode'
+                  ? t('base64_encoder_page.output_desc_encode')
+                  : t('base64_encoder_page.output_desc_decode')}
               </CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
@@ -87,12 +107,12 @@ const Base64Encoder = () => {
                 value={output}
                 readOnly
                 className="min-h-48 bg-gray-50"
-                placeholder="Result will appear here..."
+                placeholder={t('base64_encoder_page.placeholders.output')}
               />
               {output && (
                 <Button onClick={copyToClipboard} variant="outline" className="w-full">
                   <Copy className="h-4 w-4 mr-2" />
-                  Copy Result
+                  {t('base64_encoder_page.buttons.copy')}
                 </Button>
               )}
             </CardContent>

--- a/src/pages/tools/RandomNumberGenerator.tsx
+++ b/src/pages/tools/RandomNumberGenerator.tsx
@@ -1,5 +1,6 @@
 
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Dice6, Copy, RefreshCw } from "lucide-react";
 import PageHeader from "@/components/common/PageHeader";
 import { Button } from "@/components/ui/button";
@@ -15,15 +16,16 @@ const RandomNumberGenerator = () => {
   const [count, setCount] = useState(1);
   const [allowDuplicates, setAllowDuplicates] = useState(true);
   const [generatedNumbers, setGeneratedNumbers] = useState<number[]>([]);
+  const { t } = useTranslation();
 
   const generateNumbers = () => {
     if (min >= max) {
-      toast.error("הערך המינימלי חייב להיות קטן מהמקסימלי");
+      toast.error(t('random_number_generator_page.toasts.range_error'));
       return;
     }
 
     if (!allowDuplicates && (max - min + 1) < count) {
-      toast.error("לא ניתן ליצור מספר זה של מספרים ייחודיים בטווח הנתון");
+      toast.error(t('random_number_generator_page.toasts.duplicate_error'));
       return;
     }
 
@@ -46,36 +48,36 @@ const RandomNumberGenerator = () => {
     }
 
     setGeneratedNumbers(numbers);
-    toast.success("מספרים אקראיים נוצרו בהצלחה!");
+    toast.success(t('random_number_generator_page.toasts.generated'));
   };
 
   const copyToClipboard = () => {
     const numbersText = generatedNumbers.join(", ");
     navigator.clipboard.writeText(numbersText);
-    toast.success("המספרים הועתקו ללוח!");
+    toast.success(t('random_number_generator_page.toasts.copied'));
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4">
       <div className="container mx-auto max-w-4xl">
         <PageHeader
-          title="מחולל מספרים אקראיים"
-          subtitle="צור מספרים אקראיים בטווח שתבחר"
+          title={t('random_number_generator_page.title')}
+          subtitle={t('random_number_generator_page.subtitle')}
           icon={<Dice6 className="h-16 w-16 text-indigo-600" />}
           backPath="/categories/generators"
-          backLabel="חזרה לגנרטורים"
+          backLabel={t('random_number_generator_page.back')}
         />
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           <Card>
             <CardHeader>
-              <CardTitle>הגדרות</CardTitle>
-              <CardDescription>קבע את הפרמטרים ליצירת המספרים</CardDescription>
+          <CardTitle>{t('random_number_generator_page.settings_title')}</CardTitle>
+          <CardDescription>{t('random_number_generator_page.settings_desc')}</CardDescription>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <Label htmlFor="min">מינימום</Label>
+                  <Label htmlFor="min">{t('random_number_generator_page.min_label')}</Label>
                   <Input
                     id="min"
                     type="number"
@@ -84,7 +86,7 @@ const RandomNumberGenerator = () => {
                   />
                 </div>
                 <div>
-                  <Label htmlFor="max">מקסימום</Label>
+                  <Label htmlFor="max">{t('random_number_generator_page.max_label')}</Label>
                   <Input
                     id="max"
                     type="number"
@@ -95,7 +97,7 @@ const RandomNumberGenerator = () => {
               </div>
 
               <div>
-                <Label htmlFor="count">כמות מספרים</Label>
+                <Label htmlFor="count">{t('random_number_generator_page.count_label')}</Label>
                 <Input
                   id="count"
                   type="number"
@@ -112,7 +114,7 @@ const RandomNumberGenerator = () => {
                   checked={allowDuplicates}
                   onCheckedChange={setAllowDuplicates}
                 />
-                <Label htmlFor="duplicates">אפשר כפילויות</Label>
+                <Label htmlFor="duplicates">{t('random_number_generator_page.allow_duplicates')}</Label>
               </div>
 
               <Button 
@@ -121,15 +123,15 @@ const RandomNumberGenerator = () => {
                 size="lg"
               >
                 <RefreshCw className="h-4 w-4 mr-2" />
-                צור מספרים
+                {t('random_number_generator_page.generate_button')}
               </Button>
             </CardContent>
           </Card>
 
           <Card>
             <CardHeader>
-              <CardTitle>תוצאות</CardTitle>
-              <CardDescription>המספרים האקראיים שנוצרו</CardDescription>
+              <CardTitle>{t('random_number_generator_page.results_title')}</CardTitle>
+              <CardDescription>{t('random_number_generator_page.results_desc')}</CardDescription>
             </CardHeader>
             <CardContent>
               {generatedNumbers.length > 0 ? (
@@ -148,28 +150,28 @@ const RandomNumberGenerator = () => {
                   </div>
                   
                   <div className="flex gap-2">
-                    <Button 
-                      onClick={copyToClipboard} 
-                      variant="outline" 
+                    <Button
+                      onClick={copyToClipboard}
+                      variant="outline"
                       className="flex-1"
                     >
                       <Copy className="h-4 w-4 mr-2" />
-                      העתק
+                      {t('random_number_generator_page.copy')}
                     </Button>
-                    <Button 
-                      onClick={generateNumbers} 
+                    <Button
+                      onClick={generateNumbers}
                       variant="outline"
                       className="flex-1"
                     >
                       <RefreshCw className="h-4 w-4 mr-2" />
-                      צור שוב
+                      {t('random_number_generator_page.regenerate')}
                     </Button>
                   </div>
                 </div>
               ) : (
                 <div className="text-center text-gray-500 py-12">
                   <Dice6 className="h-12 w-12 mx-auto mb-4 opacity-50" />
-                  <p>לחץ על "צור מספרים" כדי להתחיל</p>
+                  <p>{t('random_number_generator_page.empty_prompt')}</p>
                 </div>
               )}
             </CardContent>


### PR DESCRIPTION
## Summary
- integrate `useTranslation` in Base64Encoder and RandomNumberGenerator pages
- move static strings to i18n JSON files
- add English and Hebrew translations

## Testing
- `npm run test:run` *(fails: 6 test files, 32 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68587c775ba88323b1457e09ca2a2d27